### PR TITLE
default Project ID must pesist across restarts

### DIFF
--- a/src/TicktickRestAPI.ts
+++ b/src/TicktickRestAPI.ts
@@ -51,9 +51,10 @@ export class TickTickRestAPI {
 					apiInitialized = true;
 					await this.api.getInboxProperties()
 					// console.log("InobxID: ", this.api.inboxId)
-					this.plugin.settings.defaultProjectId = this.api.inboxId;
-					this.plugin.settings.defaultProjectName = "Inbox";
-
+					if (!this.plugin.settings.defaultProjectId) {
+						this.plugin.settings.defaultProjectId = this.api.inboxId;
+						this.plugin.settings.defaultProjectName = "Inbox";
+					}
 				} else {
 					if (this.plugin.settings.debugMode) {
 						console.log(userSettings)


### PR DESCRIPTION
Check for updated default project id on API start. Do NOT overwrite if one selected.