### PR TITLE
Refactor task file and synchronization logic; improve default project ID handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Please see [Documentation](https://github.com/thesamim/TickTickSync/wiki/Documen
 
 1. The plugin only works with the [Tasks emoji formats](https://publish.obsidian.md/tasks/Reference/Task+Formats/About+Task+Formats). 
 2. Because Tags can't have spaces, at this time it is not possible to add a task to a project with a name that contains spaces. As a workaround `#folder_with_a_space` will be converted to `folder with a space` in TickTick
-3. If a file has a default project association (see [settings](https://github.com/thesamim/TickTickSync/wiki/Documentation#sync-control)), it is possible to create a task with a project tag other than the default project. The Task will be correctly synced to TickTick in the correct project. However, if the Task is then updated with subtasks, from TickTick, the subtasks will be synced to the project's default file rather than the file where the original parent task was created. **Additionally, the subtask will become the child of the last Task in that file.**
 
 ## Installation
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -81,6 +81,12 @@ export class TickTickService {
 				new Notice(errorString, 5000);
 				throw new Error(error.errorMessage);
 			}
+			const defaultProjectId = getSettings().defaultProjectId;
+			const defaultProjectName = getSettings().defaultProjectName;
+			if (!defaultProjectId || defaultProjectId == '' || (defaultProjectName == "Inbox" && (defaultProjectId != result.inboxId))) {
+				//no default project id or blank default project id or (default project is inbox, but the ID is different.
+				updateSettings({defaultProjectId: result.inboxId});
+			}
 			//reset the checkpoint so next time they get ALL the tasks.
 			updateSettings({checkPoint: 0});
 			await this.plugin.saveSettings();

--- a/src/services/syncModule.ts
+++ b/src/services/syncModule.ts
@@ -118,8 +118,8 @@ export class SyncMan {
 			if (deletedTaskIDs.length > 0) {
 				let saveTheseTasks: string[] = [];
 				for (const taskId of deletedTaskIDs) {
-					const location = await this.plugin.cacheOperation?.findTaskInFiles(taskId);
-					if (location) {
+					const location = this.plugin.cacheOperation?.getFilepathForTask(taskId);
+					if (location && location != filepath) {
 						log.debug('== found:', taskId, location);
 						saveTheseTasks.push(taskId);
 					}
@@ -162,8 +162,8 @@ export class SyncMan {
 		if (missingTaskIds && missingTaskIds.length > 0) {
 			let saveTheseTasks: string[] = [];
 			for (const taskId of missingTaskIds) {
-				const location = await this.plugin.cacheOperation?.findTaskInFiles(taskId);
-				if (location) {
+				const location =  this.plugin.cacheOperation?.getFilepathForTask(taskId);
+				if (location && location != filePath) {
 					log.debug("Task found in different file:", taskId, location)
 					saveTheseTasks.push(taskId);
 				}
@@ -1060,7 +1060,7 @@ export class SyncMan {
 				newTickTickTasks.forEach((newTickTickTask: ITask) => {
 					this.plugin.dateMan?.addDateHolderToTask(newTickTickTask);
 				});
-				let result = await this.plugin.fileOperation?.addTasksToFile(newTickTickTasks, false);
+				let result = await this.plugin.fileOperation?.synchronizeToVault(newTickTickTasks, false);
 				if (result) {
 					// Sleep for 1 seconds
 					await new Promise(resolve => setTimeout(resolve, 1000));
@@ -1163,7 +1163,7 @@ export class SyncMan {
 
 			if (recentUpdates.length > 0) {
 				// this.dumpArray('== Update in  Obsidian:', recentUpdates)
-				let result = await this.plugin.fileOperation?.addTasksToFile(recentUpdates, true);
+				let result = await this.plugin.fileOperation?.synchronizeToVault(recentUpdates, true);
 				if (result) {
 					// Sleep for 1 seconds
 					await new Promise(resolve => setTimeout(resolve, 1000));
@@ -1260,10 +1260,10 @@ export class SyncMan {
 
 	///End of Test
 
+	//Check if user moved the task.
 	private async checkForMoves(taskId: string, filepath: string) {
-
 		let projectMoved = false;
-		const oldFilePath = await this.plugin.cacheOperation.getFilepathForTask(taskId);
+		const oldFilePath =  this.plugin.cacheOperation.getFilepathForTask(taskId);
 		if (oldFilePath && oldFilePath !== filepath) {
 			projectMoved = true;
 		}

--- a/src/ui/settings/svelte/sections/DefaultsSection.svelte
+++ b/src/ui/settings/svelte/sections/DefaultsSection.svelte
@@ -78,6 +78,10 @@
 
 
 	async function handleDefaultProjectChange(value: string) {
+		if (!value || value == '') {
+			value = getSettings().inboxID;
+		}
+
 		getSettings().defaultProjectId = value;
 		if (value && value !== '') {
 			updateSettings({ defaultProjectName: await plugin.cacheOperation?.getProjectNameByIdFromCache(value) });


### PR DESCRIPTION
- Replaced usages of findTaskInFiles with getFilepathForTask for better task location resolution.
- Updated settings logic to auto-correct an invalid or mismatched default project ID.
- Refactored file operation methods: renamed and split out functions for better clarity (e.g., addTasksToFile ➔ synchronizeToVault, doTheAdding ➔ synchronizeToFile).
- Enhanced task syncing logic to respect parent/child relationships and ensure correct file assignment, including when project or parent changes.
- Added extra validation to DefaultsSection for empty project selection, defaulting to inbox ID if necessary.
- Improved internal function and variable names for clarity and consistency. Closes #267