### PR TITLE
Exclude #ticktick Tag from Synced Tasks While Preserving Other Tags and Add Tests

### DIFF
--- a/src/taskParser.ts
+++ b/src/taskParser.ts
@@ -334,7 +334,10 @@ export class TaskParser {
 
 		let timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-		const tags = this.getAllTagsFromLineText(textWithoutIndentation);
+                const tags = this.getAllTagsFromLineText(textWithoutIndentation);
+                const tagsWithoutTickTick = tags?.filter(
+                        (tag) => tag.toLowerCase() !== keywords.TickTick_TAG.substring(1).toLowerCase()
+                );
 
 		let projectId = await this.plugin.cacheOperation?.getDefaultProjectIdForFilepath(filepath as string);
 
@@ -344,10 +347,10 @@ export class TaskParser {
 			}
 		} else {
 			//Check if we need to add this to a specific project by tag.
-			if (tags) {
-				for (const tag of tags) {
-					let labelName = tag.replace(/#/g, '');
-					labelName = labelName.replace(/_/g, ' ');
+                        if (tagsWithoutTickTick) {
+                                for (const tag of tagsWithoutTickTick) {
+                                        let labelName = tag.replace(/#/g, '');
+                                        labelName = labelName.replace(/_/g, ' ');
 
 					let hasProjectId = await this.plugin.cacheOperation?.getProjectIdByNameFromCache(labelName);
 					if (!hasProjectId) {
@@ -390,7 +393,7 @@ export class TaskParser {
 			startDate: actualStartDate || '',
 			completedTime: allDatesStruct?.completedTime?.isoDate || '',
 			isAllDay: allDatesStruct?.isAllDay || false,
-			tags: tags || [],
+                        tags: tagsWithoutTickTick || [],
 			priority: Number(priority),
 			modifiedTime: this.plugin.dateMan?.formatDateToISO(new Date()) || '',
 			status: isCompleted ? 2 : 0, //Status: 0 is no completed. Anything else is completed.

--- a/src/test/AppPluginDefinitions.ts
+++ b/src/test/AppPluginDefinitions.ts
@@ -1,0 +1,91 @@
+// Minimal stubs for the Obsidian API used during tests.
+// These definitions only provide the symbols referenced in the codebase and
+// are not intended to replicate runtime behaviour.
+
+export class TAbstractFile {
+        constructor(public path: string = '') {}
+}
+
+export class TFile extends TAbstractFile {
+        basename = '';
+        extension = '';
+        parent: TFolder | null = null;
+        stat: Record<string, unknown> = {};
+}
+
+export class TFolder extends TAbstractFile {
+        children: TAbstractFile[] = [];
+        name = '';
+        parent: TFolder | null = null;
+}
+
+export interface ListItemCache {
+        position: unknown;
+        task?: unknown;
+}
+
+export class Vault {
+        adapter: unknown;
+        getName() {
+                return 'TestVault';
+        }
+
+        getAbstractFileByPath(path: string) {
+                return new TFile(path);
+        }
+}
+
+export class Workspace {
+        onLayoutReady(callback: () => void) {
+                callback();
+        }
+
+        getActiveViewOfType<T>(_type: any): T | null {
+                return null;
+        }
+
+        getLeaf(_forceNew?: boolean) {
+                return null;
+        }
+}
+
+export class Notice {
+        constructor(public message?: string, public timeout?: number) {}
+}
+
+export class MarkdownRenderChild {
+        constructor(public containerEl?: HTMLElement) {}
+        onload() {}
+        onunload() {}
+}
+
+export interface MarkdownPostProcessorContext {
+        docId?: string;
+}
+
+export class App {
+        vault: Vault = new Vault();
+        workspace: Workspace = new Workspace();
+        metadataCache: { getTags: () => Record<string, unknown> } = {
+                getTags: () => ({})
+        };
+        fileManager: Record<string, unknown> = {};
+        dom: { appContainerEl?: HTMLElement } = { appContainerEl: typeof document !== 'undefined' ? document.body : undefined };
+        scope: Record<string, unknown> = {};
+}
+
+export class Editor {}
+export class MarkdownView {}
+export interface MarkdownFileInfo {}
+export class WorkspaceLeaf {}
+
+export interface ISuggestOwner<T> {
+        renderSuggestion(value: T, el: HTMLElement): void;
+        selectSuggestion(value: T, evt: MouseEvent | KeyboardEvent): void;
+        getSuggestions(input: string): T[];
+}
+
+export class Scope {
+        register(_modifiers?: string[], _key?: string, _cb?: (event: KeyboardEvent) => unknown) {}
+}
+

--- a/src/test/convertLineToTask.note-destination.test.ts
+++ b/src/test/convertLineToTask.note-destination.test.ts
@@ -71,4 +71,29 @@ describe('convertLineToTask note destination', () => {
     expect(task.content).toBe('alpha\nbeta');
     expect(task.desc).toBe('');
   });
+
+  it('omits the ticktick tag when converting a line to a TickTick task', async () => {
+    (getSettings as any)().noteDelimiter = '';
+    (getSettings as any)().fileLinksInTickTick = 'noLink';
+
+    const parser = new TaskParser({} as any, {} as any);
+    const plugin = makePlugin(parser);
+    parser.plugin = plugin;
+
+    const taggedLine = `- [ ] Task #ticktick #work %%[ticktick_id:: ${id}]%%`;
+
+    const fileMap = {
+      getTaskItems: (_: string) => [],
+      getTaskRecord: (_: string) => ({
+        task: taggedLine,
+        parentId: '',
+        taskLines: [],
+      } satisfies Partial<ITaskRecord>),
+      getTaskRecordByLine: async () => ({})
+    } as any;
+
+    const task = await parser.convertLineToTask(taggedLine, 0, filepath, fileMap, null);
+
+    expect(task.tags).toEqual(['work']);
+  });
 });


### PR DESCRIPTION
Filtered out the #ticktick marker when converting Obsidian tasks to TickTick so synced tasks no longer carry the tag while still honoring other tags and project routing. 

Added a regression test to verify TickTick sync tasks exclude the #ticktick tag but retain other tags. 

Introduced minimal Obsidian API stubs to allow vitest to resolve the obsidian module during testing. 