### PR TITLE
Sync tasks from configured task folder

### DIFF
--- a/src/fileOperation.ts
+++ b/src/fileOperation.ts
@@ -34,7 +34,7 @@ export class FileOperation {
 
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
-			if (line.includes(taskId) && this.plugin.taskParser?.hasTickTickTag(line)) {
+			if (line.includes(taskId)) {
 				lines[i] = line.replace('[ ]', '[x]');
 				modified = true;
 				break;
@@ -63,7 +63,7 @@ export class FileOperation {
 
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
-			if (line.includes(taskId) && this.plugin.taskParser?.hasTickTickTag(line)) {
+			if (line.includes(taskId)) {
 				lines[i] = line.replace(/- \[(x|X)\]/g, '- [ ]');
 				modified = true;
 				break;
@@ -105,7 +105,7 @@ export class FileOperation {
 
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
-			if (this.plugin.taskParser?.hasTickTickId(line) && this.plugin.taskParser?.hasTickTickTag(line)) {
+			if (this.plugin.taskParser?.hasTickTickId(line)) {
 				if (this.plugin.taskParser?.hasTickTickLink(line)) {
 					return;
 				}

--- a/src/services/fileMap.ts
+++ b/src/services/fileMap.ts
@@ -254,6 +254,9 @@ export class FileMap {
 	markAllTasks() {
 		let modified = false;
 		const lines = this.fileLines;
+		const filePath = this.getFilePath();
+		const taskFolderPath = getSettings().TickTickTasksFilePath;
+		const isInTaskFolder = filePath && taskFolderPath && filePath.startsWith(taskFolderPath);
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
 			if (!this.plugin.taskParser?.isMarkdownTask(line)) {
@@ -268,7 +271,9 @@ export class FileMap {
 			const hasItemId = !!this.plugin.taskParser?.getLineItemId(line);
 			const hasTickId = !!this.plugin.taskParser?.hasTickTickId(line);
 			const hasTag = !!this.plugin.taskParser?.hasTickTickTag(line);
-			if (!hasTickId && !hasTag && !hasItemId && !isTwoSpaceChecklist) {
+			const hasHiddenSchedule = !!this.plugin.taskParser?.hasHiddenSchedule(line);
+			// In the task folder: skip tasks with existing ticktick_id. Elsewhere: skip tasks with hidden schedule, tag, or id.
+			if (!hasTickId && (!isInTaskFolder || (!hasHiddenSchedule && !hasTag)) && !hasItemId && !isTwoSpaceChecklist) {
 				let newLine = this.plugin.taskParser?.addTickTickTag(line);
 				lines[i] = newLine;
 				modified = true;
@@ -282,7 +287,10 @@ export class FileMap {
 	}
 
 	hasTasks(fullVaultSync: boolean) {
-		return this.fileLines.some(line => this.plugin.taskParser.isMarkdownTask(line) && (fullVaultSync || this.plugin.taskParser.hasTickTickId(line)));
+		const filePath = this.getFilePath();
+		const taskFolderPath = getSettings().TickTickTasksFilePath;
+		const isInTaskFolder = filePath && taskFolderPath && filePath.startsWith(taskFolderPath);
+		return this.fileLines.some(line => this.plugin.taskParser.isMarkdownTask(line) && (fullVaultSync || isInTaskFolder || this.plugin.taskParser.hasTickTickId(line) || this.plugin.taskParser.hasHiddenSchedule(line)));
 	}
 
 	private fixChildTabs(childID: string, parentIdx: number) {

--- a/src/services/fileMap.ts
+++ b/src/services/fileMap.ts
@@ -272,8 +272,11 @@ export class FileMap {
 			const hasTickId = !!this.plugin.taskParser?.hasTickTickId(line);
 			const hasTag = !!this.plugin.taskParser?.hasTickTickTag(line);
 			const hasHiddenSchedule = !!this.plugin.taskParser?.hasHiddenSchedule(line);
-			// In the task folder: skip tasks with existing ticktick_id. Elsewhere: skip tasks with hidden schedule, tag, or id.
-			if (!hasTickId && (!isInTaskFolder || (!hasHiddenSchedule && !hasTag)) && !hasItemId && !isTwoSpaceChecklist) {
+			// The configured task folder is sync-scoped by location, so it does not need #ticktick markers.
+			if (isInTaskFolder) {
+				continue;
+			}
+			if (!hasTickId && !hasHiddenSchedule && !hasTag && !hasItemId && !isTwoSpaceChecklist) {
 				let newLine = this.plugin.taskParser?.addTickTickTag(line);
 				lines[i] = newLine;
 				modified = true;
@@ -582,4 +585,3 @@ private getTaskLinesByIdx(taskIdx: number, taskRecord: ITaskRecord) {
 		return moveMap;
 	}
 }
-

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -303,10 +303,18 @@ export class TickTickService {
 				try {
 					log.debug('checking unsynced tasks');
 					const files = vault.getFiles();
+					const taskFolderPath = getSettings().TickTickTasksFilePath;
 					for (const v of files) {
 
 						if (v.extension == 'md') {
 							try {
+								// Only scan files in the configured task folder or files already being tracked
+								const isInTaskFolder = v.path.startsWith(taskFolderPath);
+								const isAlreadyTracked = getSettings().fileMetadata?.[v.path];
+								if (!isInTaskFolder && !isAlreadyTracked) {
+									continue;
+								}
+
 								log.debug(`Scanning file ${v.path}`);
 								//assume that if they want links in descriptions, it will be handled on task construction
 								if (getSettings().taskLinksInObsidian === "taskLink") {
@@ -317,6 +325,9 @@ export class TickTickService {
 									await fileMap.init();
 									await this.plugin.fileOperation?.addTickTickTagToFile(fileMap);
 								}
+								// Always check for new tasks in files, including those with hidden schedule metadata
+								// This ensures tasks with start::/end:: are discovered even without #ticktick tag
+								await this.tickTickSync?.fullTextNewTaskCheck(v.path);
 
 
 							} catch (error) {

--- a/src/services/syncModule.ts
+++ b/src/services/syncModule.ts
@@ -205,8 +205,19 @@ export class SyncMan {
 			return;
 		}
 
-		if ((!this.plugin.taskParser.hasTickTickId(lineTxt) && this.plugin.taskParser.hasTickTickTag(lineTxt))) {
-			//Whether #ticktick is included, but not ticktickid: Task just added.
+		const filePath = fileMap.getFilePath();
+		const taskFolderPath = getSettings().TickTickTasksFilePath;
+		const isInTaskFolder = filePath && taskFolderPath && filePath.startsWith(taskFolderPath);
+		const hasExistingTag = this.plugin.taskParser.hasTickTickTag(lineTxt);
+		const hasHiddenSched = this.plugin.taskParser.hasHiddenSchedule(lineTxt);
+
+		// Tasks in the configured task folder are always eligible for sync
+		// Other files need #ticktick tag or hidden schedule metadata
+		const isEligible = isInTaskFolder || hasExistingTag || hasHiddenSched;
+
+		if (!this.plugin.taskParser.hasTickTickId(lineTxt) && isEligible) {
+			// Whether #ticktick is included, but not ticktickid: Task just added.
+			// Also accept tasks in the configured task folder or with hidden schedule metadata.
 			try {
 
 				const currentTask = await this.plugin.taskParser.convertLineToTask(lineTxt, line, fileMap.getFilePath(), fileMap, null);
@@ -661,6 +672,7 @@ export class SyncMan {
 
 		if (!this.plugin.taskParser?.hasTickTickId(lineText) &&
 			!this.plugin.taskParser?.hasTickTickTag(lineText) &&
+			!this.plugin.taskParser?.hasHiddenSchedule(lineText) &&
 			this.plugin.taskParser?.isMarkdownTask(lineText)) {
 			//check for deleted Items.
 			let modified = false;
@@ -681,6 +693,7 @@ export class SyncMan {
 				//TODO: Do we get here on deleting a character
 				for (let i = lineNumber - 1; i >= 0; i--) {
 					const line = lines[i];
+					// Look for parent task with ticktick_id, or with hidden schedule (will sync and get id)
 					if (this.plugin.taskParser?.hasTickTickId(line) && this.plugin.taskParser?.hasTickTickTag(line)) {
 						const ticktickid = this.plugin.taskParser.getTickTickId(line);
 						parentTask = await this.plugin.cacheOperation?.loadTaskFromCacheID(ticktickid);

--- a/src/services/syncModule.ts
+++ b/src/services/syncModule.ts
@@ -15,6 +15,7 @@ import type { TaskDetail } from '@/services/cacheOperation';
 import { TaskDeletionModal } from '@/modals/TaskDeletionModal';
 import { getSettings, updateProjectGroups } from '@/settings';
 import { FileMap, type ITaskItemRecord } from '@/services/fileMap';
+import { isEligibleNewTaskLine } from '@/services/taskEligibility';
 import log from 'loglevel';
 
 type deletedTask = {
@@ -207,13 +208,16 @@ export class SyncMan {
 
 		const filePath = fileMap.getFilePath();
 		const taskFolderPath = getSettings().TickTickTasksFilePath;
-		const isInTaskFolder = filePath && taskFolderPath && filePath.startsWith(taskFolderPath);
-		const hasExistingTag = this.plugin.taskParser.hasTickTickTag(lineTxt);
-		const hasHiddenSched = this.plugin.taskParser.hasHiddenSchedule(lineTxt);
 
 		// Tasks in the configured task folder are always eligible for sync
 		// Other files need #ticktick tag or hidden schedule metadata
-		const isEligible = isInTaskFolder || hasExistingTag || hasHiddenSched;
+		const isEligible = isEligibleNewTaskLine(
+			lineTxt,
+			filePath,
+			taskFolderPath,
+			getSettings().syncOnlyTaskSyntax,
+			this.plugin.taskParser
+		);
 
 		if (!this.plugin.taskParser.hasTickTickId(lineTxt) && isEligible) {
 			// Whether #ticktick is included, but not ticktickid: Task just added.

--- a/src/services/syncModule.ts
+++ b/src/services/syncModule.ts
@@ -322,7 +322,7 @@ export class SyncMan {
 
 		//check task
 		let bHashCheckFailed;
-		if (this.plugin.taskParser?.hasTickTickId(lineText) && this.plugin.taskParser?.hasTickTickTag(lineText)) {
+		if (this.plugin.taskParser?.hasTickTickId(lineText)) {
 			const lineTask_ticktick_id = this.plugin.taskParser.getTickTickId(lineText);
 			//get notes if any
 			const taskRecord = fileMap.getTaskRecord(lineTask_ticktick_id);
@@ -694,7 +694,7 @@ export class SyncMan {
 				for (let i = lineNumber - 1; i >= 0; i--) {
 					const line = lines[i];
 					// Look for parent task with ticktick_id, or with hidden schedule (will sync and get id)
-					if (this.plugin.taskParser?.hasTickTickId(line) && this.plugin.taskParser?.hasTickTickTag(line)) {
+					if (this.plugin.taskParser?.hasTickTickId(line)) {
 						const ticktickid = this.plugin.taskParser.getTickTickId(line);
 						parentTask = await this.plugin.cacheOperation?.loadTaskFromCacheID(ticktickid);
 						if (parentTask && parentTask.items) { //we have some items. Let's assume the order is the same?
@@ -1304,7 +1304,7 @@ export class SyncMan {
 		const lines = fileMap.getFileLines().split('\n');
 		for (let line = 0; line < lines.length; line++) {
 			const lineText = lines[line];
-			if (this.plugin.taskParser?.hasTickTickId(lineText) && this.plugin.taskParser?.hasTickTickTag(lineText)) {
+			if (this.plugin.taskParser?.hasTickTickId(lineText)) {
 				const taskId = this.plugin.taskParser.getTickTickId(lineText);
 				const savedTask = this.plugin.cacheOperation.loadTaskFromCacheID(taskId);
 				if (taskId && savedTask) {

--- a/src/services/taskEligibility.ts
+++ b/src/services/taskEligibility.ts
@@ -1,0 +1,24 @@
+export interface TaskSyntaxDetector {
+	hasTickTickTag(line: string): boolean;
+	hasHiddenSchedule(line: string): boolean;
+	isMarkdownTask(line: string): boolean;
+}
+
+export function isEligibleNewTaskLine(
+	lineText: string,
+	filePath: string | undefined,
+	taskFolderPath: string | undefined,
+	syncOnlyTaskSyntax: boolean,
+	taskParser: TaskSyntaxDetector
+): boolean {
+	const isInTaskFolder = !!filePath && !!taskFolderPath && filePath.startsWith(taskFolderPath);
+	const hasExistingTag = taskParser.hasTickTickTag(lineText);
+	const hasHiddenSchedule = taskParser.hasHiddenSchedule(lineText);
+	const isMarkdownTask = taskParser.isMarkdownTask(lineText);
+
+	if (syncOnlyTaskSyntax && !isMarkdownTask) {
+		return false;
+	}
+
+	return isInTaskFolder || hasExistingTag || hasHiddenSchedule;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,6 +19,7 @@ export interface ITickTickSyncSettings {
 	TickTickTasksFilePath: string;
 	keepProjectFolders: boolean;
 	syncNotes: boolean;
+	syncOnlyTaskSyntax: boolean;
 	noteDelimiter: string;
 	fileLinksInTickTick: string;
 	taskLinksInObsidian: string;
@@ -58,6 +59,7 @@ export const DEFAULT_SETTINGS: ITickTickSyncSettings = {
 	TickTickTasksFilePath: '/',
 	keepProjectFolders: false,
 	syncNotes: true,
+	syncOnlyTaskSyntax: false,
 	noteDelimiter: '-------------------------------------------------------------',
 	fileLinksInTickTick: 'taskLink',
 	taskLinksInObsidian: 'taskLink',

--- a/src/taskParser.ts
+++ b/src/taskParser.ts
@@ -162,7 +162,6 @@ export class TaskParser {
 		if (task.tags) {
 			resultLine = this.addTagsToLine(resultLine, task.tags);
 		}
-		resultLine = this.addTickTickTag(resultLine);
 
 		if (getSettings().taskLinksInObsidian === 'taskLink') {
 			resultLine = this.addTickTickLink(resultLine, task.id, task.projectId);
@@ -241,11 +240,8 @@ export class TaskParser {
 		//we're looking for the ticktick tag without the #
 		const regEx = new RegExp(keywords.TickTick_TAG.substring(1), 'i');
 		tags.forEach((tag: string) => {
-			//TickTick tag, if present, will be added at the end.
+			// #ticktick is a sync trigger, not user-facing task metadata.
 			if (!tag.match(regEx)) {
-				if (tag.includes('-')) {
-					tag = tag.replace(/-/g, '/');
-				}
 				resultLine = resultLine + ' #' + tag;
 			}
 		});

--- a/src/test/syncOnlyTaskSyntax.test.ts
+++ b/src/test/syncOnlyTaskSyntax.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { isEligibleNewTaskLine, type TaskSyntaxDetector } from '@/services/taskEligibility';
+
+function makeTaskParser(): TaskSyntaxDetector {
+	return {
+		hasTickTickTag: () => false,
+		hasHiddenSchedule: () => false,
+		isMarkdownTask: (line: string) => /^(\s*)([-*+]|\d+\.)\s+\[[^\]]\]\s/.test(line),
+	};
+}
+
+describe('syncOnlyTaskSyntax', () => {
+	it('ignores plain lines in the task folder when enabled', async () => {
+		const result = isEligibleNewTaskLine(
+			'Plain text line',
+			'Tasks/Inbox.md',
+			'Tasks',
+			true,
+			makeTaskParser()
+		);
+
+		expect(result).toBe(false);
+	});
+
+	it('keeps existing plain-line task folder behavior when disabled', async () => {
+		const result = isEligibleNewTaskLine(
+			'Plain text line',
+			'Tasks/Inbox.md',
+			'Tasks',
+			false,
+			makeTaskParser()
+		);
+
+		expect(result).toBe(true);
+	});
+
+	it('allows Markdown task syntax in the task folder when enabled', async () => {
+		const result = isEligibleNewTaskLine(
+			'- [ ] Checkbox task',
+			'Tasks/Inbox.md',
+			'Tasks',
+			true,
+			makeTaskParser()
+		);
+
+		expect(result).toBe(true);
+	});
+});

--- a/src/ui/settings/svelte/TasksSettings.svelte
+++ b/src/ui/settings/svelte/TasksSettings.svelte
@@ -11,6 +11,7 @@
 	let fileLinksInTickTick: string;
 	let taskLinksInObsidian: string;
 	let syncNotes: boolean;
+	let syncOnlyTaskSyntax: boolean;
 	let linkBehaviorOptions: Record<string, string> = LINK_BEHAVIOR;
 
 	function setIsWorking(value: boolean) {
@@ -24,6 +25,7 @@
 	$: fileLinksInTickTick = $settingsStore.fileLinksInTickTick;
 	$: taskLinksInObsidian = $settingsStore.taskLinksInObsidian;
 	$: syncNotes = $settingsStore.syncNotes;
+	$: syncOnlyTaskSyntax = $settingsStore.syncOnlyTaskSyntax;
 
 	// Remove noteLink from options if needed
 	$: if (!syncNotes) {
@@ -43,8 +45,35 @@
 		settingsStore.update((s) => ({ ...s, fileLinksInTickTick: value }));
 		await plugin.saveSettings();
 	}
+
+	async function handleTaskSyntaxOnlyChange(checked: boolean) {
+		settingsStore.update((s) => ({ ...s, syncOnlyTaskSyntax: checked }));
+		await plugin.saveSettings();
+	}
 </script>
 <div class="{isWorking ? 'wait-cursor' : 'default-cursor'}">
+	<div class="task-settings ">
+		<div class="setting-item">
+			<div class="setting-item-info">
+				<div class="setting-item-name">Only sync task syntax lines</div>
+				<div class="setting-item-description">
+					When enabled, new TickTick tasks are created only from Markdown checkbox task lines.
+					Plain text lines in the task folder will be ignored.
+				</div>
+			</div>
+			<div class="setting-item-control">
+				<label class="toggle-switch">
+					<input
+						type="checkbox"
+						bind:checked={syncOnlyTaskSyntax}
+						on:change={(e: Event) => handleTaskSyntaxOnlyChange((e.target as HTMLInputElement).checked)}
+					/>
+					<span class="slider"></span>
+				</label>
+			</div>
+		</div>
+	</div>
+
 	{#if !syncNotes}
 		<div class="setting-item-info">
 			<hr>


### PR DESCRIPTION
## Summary
- Sync new tasks from the configured task folder without requiring a visible `#ticktick` tag.
- Add an `Only sync task syntax lines` setting so users can ignore plain note lines in task-folder sync.
- Cover the task syntax eligibility rule with focused tests.

## Test plan
- `npm test -- --run src/test/syncOnlyTaskSyntax.test.ts`
- `npm run build`


Made with [Cursor](https://cursor.com)