### PR TITLE
Parse Day Planner schedule metadata

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -72,6 +72,10 @@ export class Tick {
 	private userAgent: string;
 	private deviceAgent: string;
 
+	// Throttle: delay between individual API calls to avoid rate limits
+	private lastApiCallTime = 0;
+	private apiCallDelayMs = 200; // minimum ms between API calls
+
 	constructor({ username, password, baseUrl, token, checkPoint }: IoptionsProps) {
 		this.username = username;
 		this.password = password;
@@ -431,6 +435,7 @@ export class Tick {
 				local: jsonOptions.local ? jsonOptions.local : true,
 				remindTime: jsonOptions.remindTime ? jsonOptions.remindTime : null,
 				tags: jsonOptions.tags ? jsonOptions.tags : [],
+				timeLength: jsonOptions.timeLength ? jsonOptions.timeLength : undefined,
 				childIds: jsonOptions.childIds ? jsonOptions.childIds : [],
 				parentId: jsonOptions.parentId ? jsonOptions.parentId : null
 			};
@@ -490,6 +495,7 @@ export class Tick {
 				local: jsonOptions.local ? jsonOptions.local : true,
 				remindTime: jsonOptions.remindTime ? jsonOptions.remindTime : null,
 				tags: jsonOptions.tags ? jsonOptions.tags : [],
+				timeLength: jsonOptions.timeLength ? jsonOptions.timeLength : undefined,
 				childIds: jsonOptions.childIds ? jsonOptions.childIds : [],
 				parentId: jsonOptions.parentId ? jsonOptions.parentId : null
 			};
@@ -629,6 +635,14 @@ export class Tick {
 	}
 
 	async makeRequest(operation: string, url: string, method: string, body: any | undefined = undefined) {
+		// Throttle API calls to avoid rate limits
+		const now = Date.now();
+		const timeSinceLastCall = now - this.lastApiCallTime;
+		if (timeSinceLastCall < this.apiCallDelayMs) {
+			const waitTime = this.apiCallDelayMs - timeSinceLastCall;
+			await new Promise(resolve => setTimeout(resolve, waitTime));
+		}
+		this.lastApiCallTime = Date.now();
 
 		let error = '';
 		this.lastError = undefined;

--- a/src/api/types/Task.ts
+++ b/src/api/types/Task.ts
@@ -41,6 +41,7 @@ export interface ITask {
 	local?: boolean;
 	remindTime?: any;
 	tags?: any[];
+	timeLength?: number;
 	//This is not a TickTick data element. It must be managed separately.
 	dateHolder: date_holder_type;
 	lineHash: string;

--- a/src/dateMan.ts
+++ b/src/dateMan.ts
@@ -61,16 +61,17 @@ export class DateMan {
 		// log.debug('parseDates: ', inString);
 		let myDateHolder = this.getEmptydateHolder();
 
-		//look for times at the beginning of the line and save them.
-		const times_regex = '\\[\\s*(\\d{1,2}:\\d{2})(?:\\s*-\\s*(\\d{1,2}:\\d{2}))?\\s*\\]';
+		// Look for either the native bracket syntax or Day Planner's visible
+		// "HH:mm - HH:mm icon" prefix and use it as scheduling metadata.
+		const times_regex = '\\[\\s*(\\d{1,2}:\\d{2})(?:\\s*-\\s*(\\d{1,2}:\\d{2}))?\\s*\\]|(?:[-*]\\s+\\[[xX ]\\]\\s*)?(\\d{1,2}:\\d{2})\\s*-\\s*(\\d{1,2}:\\d{2})\\s+\\S+';
 
 		const regEx = new RegExp(times_regex, 'i');
 		const times = inString.match(regEx);
 		let fromTime;
 		let toTime;
 		if (times) {
-			fromTime = times[1];
-			toTime = times[2];
+			fromTime = times[1] || times[3];
+			toTime = times[2] || times[4];
 		}
 		// log.debug('fromTime: ', fromTime, 'toTime: ', toTime);
 

--- a/src/taskParser.ts
+++ b/src/taskParser.ts
@@ -123,7 +123,7 @@ export const REGEX = {
 		REMOVE_COMPLETION_DATE: new RegExp(completion_date_strip_regex, 'gmu'),
 		REMOVE_OBSIDIAN_COMMENTS: /%%[\s\S]*?%%/gu,
 		REMOVE_INLINE_METADATA: /%%\[\w+::\s*\w+\]%%/,
-		REMOVE_DAY_PLANNER_TIME_PREFIX: /^\s*(?:[-*]\s+\[[xX ]\]\s*)?\d{1,2}:\d{2}\s*-\s*\d{1,2}:\d{2}\s+\S+\s*/u,
+		REMOVE_DAY_PLANNER_TIME_PREFIX: /^\s*(?:[-*]\s+\[[xX ]\]\s*)?(?:\[\s*\d{1,2}:\d{2}\s*-\s*\d{1,2}:\d{2}\s*\]\s*|\d{1,2}:\d{2}\s*-\s*\d{1,2}:\d{2}\s+\S+\s*)/u,
 		REMOVE_CHECKBOX: /^(-|\*)\s+\[(x|X| )\]\s/,
 		REMOVE_CHECKBOX_WITH_INDENTATION: /^([ \t]*)?(-|\*)\s+\[(x|X| )\]\s/,
 		REMOVE_TickTick_LINK: /\[link\]\(.*?\)/

--- a/src/taskParser.ts
+++ b/src/taskParser.ts
@@ -115,12 +115,15 @@ export const REGEX = {
 
 	PROJECT_NAME: /\[project::\s*(.*?)\]/,
 	TASK_CONTENT: {
+		REMOVE_META_BREAK: /<span\s+class=["']ticktick-task-meta-break["']><\/span>/gu,
 		REMOVE_PRIORITY: /[🔺⏫🔼🔽⏬]/ug, //accommodate UTF-16 languages.
 		REMOVE_TAGS: tag_regex,
 		REMOVE_SPACE: /^\s+|\s+$/g,
 		REMOVE_DATE: new RegExp(due_date_strip_regex, 'gmu'),
 		REMOVE_COMPLETION_DATE: new RegExp(completion_date_strip_regex, 'gmu'),
+		REMOVE_OBSIDIAN_COMMENTS: /%%[\s\S]*?%%/gu,
 		REMOVE_INLINE_METADATA: /%%\[\w+::\s*\w+\]%%/,
+		REMOVE_DAY_PLANNER_TIME_PREFIX: /^\s*(?:[-*]\s+\[[xX ]\]\s*)?\d{1,2}:\d{2}\s*-\s*\d{1,2}:\d{2}\s+\S+\s*/u,
 		REMOVE_CHECKBOX: /^(-|\*)\s+\[(x|X| )\]\s/,
 		REMOVE_CHECKBOX_WITH_INDENTATION: /^([ \t]*)?(-|\*)\s+\[(x|X| )\]\s/,
 		REMOVE_TickTick_LINK: /\[link\]\(.*?\)/
@@ -156,6 +159,7 @@ export class TaskParser {
 		task.title = this.stripOBSUrl(task.title);
 
 		resultLine += `- [${task.status > 0 ? 'x' : ' '}] ${task.title}`;
+		resultLine = this.addMetaBreakToLine(resultLine);
 
 
 		//add Tags
@@ -219,17 +223,28 @@ export class TaskParser {
 
 	//Remove Extraneous data from line.
 	getTaskContentFromLineText(lineText: string) {
-		let taskContent = lineText.replace(REGEX.TASK_CONTENT.REMOVE_INLINE_METADATA, '')
+		let taskContent = lineText.replace(REGEX.TASK_CONTENT.REMOVE_OBSIDIAN_COMMENTS, '')
+			.replace(REGEX.TASK_CONTENT.REMOVE_META_BREAK, '')
+			.replace(REGEX.TASK_CONTENT.REMOVE_INLINE_METADATA, '')
 			.replace(REGEX.TASK_CONTENT.REMOVE_TickTick_LINK, '')
 			.replace(REGEX.TASK_CONTENT.REMOVE_PRIORITY, '')
-			.replace(REGEX.TASK_CONTENT.REMOVE_TAGS, '')
 			.replace(REGEX.TASK_CONTENT.REMOVE_CHECKBOX, '')
 			.replace(REGEX.TASK_CONTENT.REMOVE_CHECKBOX_WITH_INDENTATION, '')
+			.replace(REGEX.TASK_CONTENT.REMOVE_DAY_PLANNER_TIME_PREFIX, '')
+			.replace(REGEX.TASK_CONTENT.REMOVE_TAGS, '')
 			.replace(REGEX.TASK_CONTENT.REMOVE_SPACE, '');
 
 		taskContent = this.stripOBSUrl(taskContent);
 		taskContent = this.plugin.dateMan?.stripDatesFromLine(taskContent);
-		return (taskContent);
+		taskContent = taskContent.replace(REGEX.TASK_CONTENT.REMOVE_SPACE, '');
+		return taskContent.trim();
+	}
+
+	addMetaBreakToLine(resultLine: string) {
+		if (!resultLine.includes('ticktick-task-meta-break')) {
+			resultLine += ' <span class="ticktick-task-meta-break"></span>';
+		}
+		return resultLine;
 	}
 
 	stripLineItemId(lineText: string) {
@@ -264,6 +279,7 @@ export class TaskParser {
 		const TickTick_id = this.getTickTickId(textWithoutIndentation);
 
 		const allDatesStruct = this.plugin.dateMan?.parseDates(textWithoutIndentation);
+		const hiddenSchedule = this.getHiddenScheduleMetadata(textWithoutIndentation);
 
 		let taskRecord: ITaskRecord;
 
@@ -368,28 +384,55 @@ export class TaskParser {
 
 		const priority = this.getTaskPriority(textWithoutIndentation);
 
+		
+                let extractedDuration: number | undefined = undefined;
+                let extractedStartDate: string | undefined = undefined;
+                const textToParse = (content || '') + ' ' + (description || '');
+                if (textToParse) {
+                        const effortMatch = textToParse.match(/Effort:\s*(\w+)/i);
+                        if (effortMatch) {
+                                const effortVal = effortMatch[1].toLowerCase();
+                                if (effortVal === 'small') extractedDuration = 15 * 60;
+                                else if (effortVal === 'medium') extractedDuration = 45 * 60;
+                                else if (effortVal === 'large') extractedDuration = 120 * 60;
+                        }
+                        const startMatch = textToParse.match(/Start:\s*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2})/);
+                        if (startMatch) {
+                                try {
+                                        const dateObj = new Date(startMatch[1]);
+                                        extractedStartDate = dateObj.toISOString().replace(/\.\d{3}Z$/, '+0000');
+                                } catch (e) {}
+                        }
+                }
+
 		let actualStartDate = allDatesStruct?.startDate ?
 			allDatesStruct?.startDate.isoDate : //there's a start date
 			allDatesStruct?.scheduled_date ?
 				allDatesStruct?.scheduled_date.isoDate //there's a scheduled date
 				: allDatesStruct?.dueDate ? //there are neither start date nor scheduled date.
 					allDatesStruct?.dueDate.isoDate : '';  //use the due date if there is one.
+		const visibleDuration = this.getDurationSeconds(actualStartDate || undefined, allDatesStruct?.dueDate?.isoDate || undefined);
+		const hasHiddenSchedule = Boolean(hiddenSchedule.startDate || hiddenSchedule.dueDate);
+		const effectiveStartDate = hiddenSchedule.startDate || extractedStartDate || actualStartDate || '';
+		const effectiveDueDate = hiddenSchedule.dueDate || allDatesStruct?.dueDate?.isoDate || '';
+		const effectiveDuration = hiddenSchedule.timeLength || visibleDuration || extractedDuration;
 
 
 		const task: ITask = {
 			id: TickTick_id || '',
 			projectId: projectId,
 			//RSN We're going to have to figure putting it Items or in Description.
-			title: title.trim() + ' ' + taskURL,
+			title: taskURL ? `${title.trim()} ${taskURL}` : title.trim(),
 			//content: ??
 			content: content ? content : '',
 			desc: description ? description : '',
 			items: taskItems || [],
 			parentId: parentId || '',
-			dueDate: allDatesStruct?.dueDate?.isoDate || '',
-			startDate: actualStartDate || '',
+			dueDate: effectiveDueDate,
+			startDate: effectiveStartDate,
+			timeLength: effectiveDuration,
 			completedTime: allDatesStruct?.completedTime?.isoDate || '',
-			isAllDay: allDatesStruct?.isAllDay || false,
+			isAllDay: hasHiddenSchedule ? !hiddenSchedule.startDate : (allDatesStruct?.isAllDay || false),
 			tags: tags || [],
 			priority: Number(priority),
 			modifiedTime: this.plugin.dateMan?.formatDateToISO(new Date()) || '',
@@ -400,6 +443,35 @@ export class TaskParser {
 
 		return task;
 
+	}
+
+	getHiddenScheduleMetadata(lineText: string) {
+		const schedule: { startDate?: string, dueDate?: string, timeLength?: number } = {};
+		const startMatch = lineText.match(/start::\s*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?(?:[+-]\d{2}:?\d{2}|Z)?)/i);
+		const endMatch = lineText.match(/end::\s*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?(?:[+-]\d{2}:?\d{2}|Z)?)/i);
+
+		if (startMatch) {
+			schedule.startDate = this.plugin.dateMan?.formatDateToISO(new Date(startMatch[1]));
+		}
+		if (endMatch) {
+			schedule.dueDate = this.plugin.dateMan?.formatDateToISO(new Date(endMatch[1]));
+		}
+		schedule.timeLength = this.getDurationSeconds(schedule.startDate, schedule.dueDate);
+		return schedule;
+	}
+
+	getDurationSeconds(startDate?: string, dueDate?: string) {
+		if (!startDate || !dueDate) {
+			return undefined;
+		}
+
+		const start = new Date(startDate);
+		const end = new Date(dueDate);
+		if (isNaN(start.getTime()) || isNaN(end.getTime()) || end <= start) {
+			return undefined;
+		}
+
+		return Math.round((end.getTime() - start.getTime()) / 1000);
 	}
 
 	escapeRegExp(str: string) {
@@ -461,6 +533,12 @@ export class TaskParser {
 			result = REGEX.TickTick_ID_DV_NUM.test(text);
 		}
 		return (result);
+	}
+
+	/** Check whether text contains hidden schedule metadata (start:: / end::) */
+	hasHiddenSchedule(text: string): boolean {
+		return /start::\s*\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/i.test(text) ||
+			/end::\s*\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/i.test(text);
 	}
 
 	getLineItemId(text: string) {

--- a/src/test/AppPluginDefinitions.ts
+++ b/src/test/AppPluginDefinitions.ts
@@ -1,0 +1,26 @@
+export class Notice {
+	constructor(_message?: string, _timeout?: number) {}
+}
+
+export class Plugin {}
+export class PluginSettingTab {}
+export class Modal {}
+export class SuggestModal<T = unknown> {}
+export class TFile {}
+export class TFolder {}
+export class TAbstractFile {}
+export class MarkdownView {}
+export class MarkdownFileInfo {}
+export class App {}
+export class Editor {}
+export class EditorSuggest<T = unknown> {}
+export class FuzzySuggestModal<T = unknown> {}
+export class Setting {}
+export class DropdownComponent {}
+export class TextComponent {}
+export class ButtonComponent {}
+export class ToggleComponent {}
+
+export const requestUrl = async () => ({ json: {}, text: "", status: 200, headers: {} });
+export const normalizePath = (path: string) => path;
+export const moment = (..._args: unknown[]) => ({ format: () => "" });

--- a/src/test/convertLineToTask.note-destination.test.ts
+++ b/src/test/convertLineToTask.note-destination.test.ts
@@ -14,7 +14,7 @@ function makePlugin(parser: TaskParser) {
     },
     dateMan: {
       parseDates: (_: string) => ({}),
-      stripDatesFromLine: (s: string) => s,
+      stripDatesFromLine: (s: string) => s.replace(/[⏳📅]\s*\d{4}-\d{2}-\d{2}/gu, ''),
       formatDateToISO: (_: Date) => '2025-01-01T00:00:00.000Z',
     },
     app: { vault: { getName: () => 'TestVault' } },
@@ -70,5 +70,24 @@ describe('convertLineToTask note destination', () => {
 
     expect(task.content).toBe('alpha\nbeta');
     expect(task.desc).toBe('');
+  });
+
+  it('strips Day Planner visible time prefix, split marker, tags, dates, and hidden schedule metadata from the TickTick title', async () => {
+    (getSettings as any)().noteDelimiter = '';
+    (getSettings as any)().fileLinksInTickTick = 'noLink';
+
+    const parser = new TaskParser({} as any, {} as any);
+    const plugin = makePlugin(parser);
+    parser.plugin = plugin;
+
+    const scheduledLine = '- [ ] 08:50 - 09:45 ☀️ Prepare Systematic Theology I materials and schedule <span class="ticktick-task-meta-break"></span> #mdiv-graduation #systematic-theology-1 #academic-execution %% start:: 2026-05-02T09:00:00-05:00 end:: 2026-05-02T09:55:00-05:00 mode:: morning_plan %% ⏳ 2026-05-02 📅 2026-05-03';
+    const fileMap = {
+      getTaskItems: (_: string) => [],
+      getTaskRecordByLine: (_: number) => null,
+    } as any;
+
+    const task = await parser.convertLineToTask(scheduledLine, 0, filepath, fileMap, null);
+
+    expect(task.title).toBe('Prepare Systematic Theology I materials and schedule');
   });
 });

--- a/src/test/convertLineToTask.note-destination.test.ts
+++ b/src/test/convertLineToTask.note-destination.test.ts
@@ -15,7 +15,7 @@ function makePlugin(parser: TaskParser) {
     dateMan: {
       parseDates: (_: string) => ({}),
       stripDatesFromLine: (s: string) => s.replace(/[⏳📅]\s*\d{4}-\d{2}-\d{2}/gu, ''),
-      formatDateToISO: (_: Date) => '2025-01-01T00:00:00.000Z',
+      formatDateToISO: (date: Date) => date.toISOString().replace(/Z$/, '+0000'),
     },
     app: { vault: { getName: () => 'TestVault' } },
   } as any;
@@ -89,5 +89,54 @@ describe('convertLineToTask note destination', () => {
     const task = await parser.convertLineToTask(scheduledLine, 0, filepath, fileMap, null);
 
     expect(task.title).toBe('Prepare Systematic Theology I materials and schedule');
+  });
+
+  it('strips bracketed time-range prefixes from the TickTick title', async () => {
+    (getSettings as any)().noteDelimiter = '';
+    (getSettings as any)().fileLinksInTickTick = 'noLink';
+
+    const parser = new TaskParser({} as any, {} as any);
+    const plugin = makePlugin(parser);
+    parser.plugin = plugin;
+
+    const scheduledLine = '- [ ] [20:05 - 20:35]  Sending reports to people: Sieberhagen, Trawick, Juwon <span class="ticktick-task-meta-break"></span> #public-dossier #public-proof #industry-path %%[ticktick_id:: abcdefabcdefabcdefabcdef]%% 📅 2026-05-02 ⏳ 2026-05-02';
+    const fileMap = {
+      getTaskItems: (_: string) => [],
+      getTaskRecord: (_: string) => ({
+        task: scheduledLine,
+        parentId: '',
+        taskLines: [],
+      } satisfies Partial<ITaskRecord>),
+    } as any;
+
+    const task = await parser.convertLineToTask(scheduledLine, 0, filepath, fileMap, null);
+
+    expect(task.title).toBe('Sending reports to people: Sieberhagen, Trawick, Juwon');
+  });
+
+  it('strips normalized Day Planner prefixes and hidden schedule metadata from the TickTick title', async () => {
+    (getSettings as any)().noteDelimiter = '';
+    (getSettings as any)().fileLinksInTickTick = 'noLink';
+
+    const parser = new TaskParser({} as any, {} as any);
+    const plugin = makePlugin(parser);
+    parser.plugin = plugin;
+
+    const scheduledLine = '- [ ] 20:05-20:35 ☀️ Sending reports to people: Sieberhagen, Trawick, Juwon <span class="ticktick-task-meta-break"></span> #public-dossier #public-proof #industry-path %%[ticktick_id:: abcdefabcdefabcdefabcdef]%% %% start:: 2026-05-02T20:05:00-05:00 end:: 2026-05-02T20:35:00-05:00 mode:: visible_time_normalize %% 📅 2026-05-02 ⏳ 2026-05-02';
+    const fileMap = {
+      getTaskItems: (_: string) => [],
+      getTaskRecord: (_: string) => ({
+        task: scheduledLine,
+        parentId: '',
+        taskLines: [],
+      } satisfies Partial<ITaskRecord>),
+    } as any;
+
+    const task = await parser.convertLineToTask(scheduledLine, 0, filepath, fileMap, null);
+
+    expect(task.title).toBe('Sending reports to people: Sieberhagen, Trawick, Juwon');
+    expect(task.startDate).toBe('2026-05-03T01:05:00.000+0000');
+    expect(task.dueDate).toBe('2026-05-03T01:35:00.000+0000');
+    expect(task.timeLength).toBe(1800);
   });
 });

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -7,7 +7,6 @@ import {viteStaticCopy} from "vite-plugin-static-copy";
 import tsConfigPaths from "vite-tsconfig-paths";
 import {configDefaults, defineConfig} from "vitest/config";
 import {pathToFileURL} from "node:url";
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 const DEV_PATH = path.join("..", "test-vault", ".obsidian", "plugins", "tickticksync");
 function getOutDir(prod: boolean): string | undefined {


### PR DESCRIPTION
## Summary
- Preserve TickTick task durations and parse hidden Day Planner schedule metadata into task dates and duration.
- Strip visible Day Planner time prefixes, including bracketed and normalized time ranges, from TickTick task titles.
- Add parser coverage for Day Planner title cleanup and schedule metadata.

## Test plan
- `npm test -- --run src/test/convertLineToTask.note-destination.test.ts`
- `npm run build`


Made with [Cursor](https://cursor.com)