### PR TITLE
Fix all-day task date drift bug (timezone parsing in extractDates)

### DIFF
--- a/src/dateMan.ts
+++ b/src/dateMan.ts
@@ -54,7 +54,7 @@ export class DateMan {
 		output: a dateholer struct
 		Called when a task is being examined for changes, or ready for update. (Called from convertLineToTask.)
 	*/
-	parseDates(inString: string): date_holder_type {
+	parseDates(inString: string, timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone): date_holder_type {
 		// log.debug('parseDates: ', inString);
 		let myDateHolder = this.getEmptydateHolder();
 
@@ -73,7 +73,7 @@ export class DateMan {
 
 		for (const [key, value] of Object.entries(date_emoji)) {
 			// log.debug("--", dateEmojiKey, date_emoji[dateEmojiKey]);
-			let dateItem = this.extractDates(key, inString, value);
+			let dateItem = this.extractDates(key, inString, value, timeZone);
 			if (dateItem) {
 				if ((key == 'scheduled_date') || (key == 'startDate')) {
 					if ((fromTime) && (!dateItem.hasATime)) {
@@ -321,6 +321,36 @@ export class DateMan {
 		return convertedDate.toISOString().replace(/Z$/, '+0000');
 	}
 
+	// Compute the UTC instant that corresponds to midnight of `dateString`
+	// (YYYY-MM-DD) in the given IANA `timeZone`. Needed for all-day dates:
+	// TickTick interprets an all-day task's date-only value relative to the
+	// task's own timeZone field, not UTC, so a literal UTC midnight is only
+	// correct for UTC-zone users -- everyone west of UTC would see the date
+	// roll back a day. Uses the standard Intl.DateTimeFormat offset trick
+	// since JS Date has no built-in IANA zone support.
+	zonedMidnightToUTC(dateString: string, timeZone: string): Date {
+		const naiveUTC = new Date(`${dateString}T00:00:00.000Z`);
+		const dtf = new Intl.DateTimeFormat('en-US', {
+			timeZone,
+			hourCycle: 'h23',
+			year: 'numeric', month: '2-digit', day: '2-digit',
+			hour: '2-digit', minute: '2-digit', second: '2-digit'
+		});
+		const parts: Record<string, string> = {};
+		for (const part of dtf.formatToParts(naiveUTC)) {
+			parts[part.type] = part.value;
+		}
+		// What UTC instant would produce these same wall-clock digits?
+		// The difference between that and naiveUTC is timeZone's offset
+		// at this instant (DST-aware, since we evaluated at naiveUTC).
+		const asIfUTC = Date.UTC(
+			Number(parts.year), Number(parts.month) - 1, Number(parts.day),
+			Number(parts.hour), Number(parts.minute), Number(parts.second)
+		);
+		const offsetMs = asIfUTC - naiveUTC.getTime();
+		return new Date(naiveUTC.getTime() - offsetMs);
+	}
+
 	utcToLocal(utcDateString: string) {
 		const date = new Date(utcDateString);
 		//Regardless of host date/time format, we want to parse for "en-US" format
@@ -417,7 +447,7 @@ export class DateMan {
 		return timeString;
 	}
 
-	private extractDates(key: string, inString: string, dateEmoji: date_emoji) {
+	private extractDates(key: string, inString: string, dateEmoji: date_emoji, timeZone: string) {
 
 		let dateItem: date_time_type | null = null;
 		const date_regex = `(${dateEmoji})\\s(\\d{4}-\\d{2}-\\d{2})\\s*(\\d{1,}:\\d{2})*`;
@@ -425,22 +455,19 @@ export class DateMan {
 		let dateData = inString.match(date_regex);
 
 		if (dateData) {
-			let returnDate = null;
+			let returnDate: string;
 			let bhasATime = false;
 			if (!dateData[3]) {
-				// When TT schedules an all day event, it converts the due date to midnight of the next day.
-				// Meaning that when the date is displayed in TT it is reflecting the date adjusted to the time zone
-				// the user is seeing in the User interface, and it .
-				// Likewise in OBS the date is displayed to reflect the local timezone.
-				// In the fullness of time, figure out if there's a way around this.
-				// let timeToSet = '';
-				// if (key == 'dueDate') {
-				// 	timeToSet = '23:59';
-				// } else if ((key == 'scheduled_date') || (key == 'startDate')) {
-				// 	timeToSet = '00:01';
-				// }
-				returnDate = `${dateData[2]}T00:00:00.000`;
+				// TickTick interprets an all-day task's dueDate relative to
+				// the task's own timeZone field, not UTC -- confirmed live
+				// (#366 follow-up, 2026-07-27): a naive UTC midnight showed
+				// up a day early in TickTick's own UI for a UTC-negative
+				// host. Compute the actual UTC instant that corresponds to
+				// midnight of this date in `timeZone`, so it round-trips as
+				// the same calendar day in TickTick's UI regardless of host
+				// OS timezone.
 				bhasATime = false;
+				returnDate = this.formatDateToISO(this.zonedMidnightToUTC(dateData[2], timeZone));
 			} else {
 				if (dateData[3].includes('24:')) {
 					dateData[3] = dateData[3].replace('24:', '00:');
@@ -448,11 +475,10 @@ export class DateMan {
 				let [hours, minutes] = dateData[3].split(':');
 				hours = String(hours).padStart(2, '0');
 				minutes = String(minutes).padStart(2, '0');
-				returnDate = `${dateData[2]}T${hours}:${minutes}`;
 				bhasATime = true;
+				returnDate = this.formatDateToISO(new Date(`${dateData[2]}T${hours}:${minutes}`));
 			}
 
-			returnDate = this.formatDateToISO(new Date(returnDate));
 			dateItem = {
 				hasATime: bhasATime,
 				date: dateData[2],

--- a/src/test/dateMan_timezone_drift.test.ts
+++ b/src/test/dateMan_timezone_drift.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Scope: DateMan.parseDates() producing a correct, timezone-aware isoDate
+ * for all-day (date-only) values -- the #366 regression and its 2026-07-27
+ * follow-up correction.
+ *
+ * TickTick interprets an all-day task's dueDate relative to the task's own
+ * timeZone field, not UTC (confirmed live: a naive UTC-midnight value
+ * displayed as the wrong day in TickTick's own UI for a UTC-negative
+ * zone). So the correct isoDate is the actual UTC instant corresponding to
+ * midnight of the given date *in the task's timezone* -- not a literal
+ * "just append Z" UTC midnight, and not dependent on host OS timezone
+ * either.
+ *
+ * Distinct from dateMan_scheduled.test.ts, which covers
+ * addDateHolderToTask's field *preservation* logic (merging old/new task
+ * date holders), not date parsing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DateMan } from '../dateMan';
+
+// Mock logger to avoid window.moment issues
+vi.mock('@/utils/logger', () => ({
+	default: {
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		info: vi.fn(),
+	}
+}));
+
+describe('DateMan.parseDates all-day timezone handling (#366)', () => {
+	let dateMan: DateMan;
+	let originalTZ: string | undefined;
+
+	beforeEach(() => {
+		dateMan = new DateMan();
+		originalTZ = process.env.TZ;
+	});
+
+	afterEach(() => {
+		process.env.TZ = originalTZ;
+	});
+
+	it.each([
+		// [task timeZone, date, expected UTC isoDate for midnight in that zone]
+		['America/Mexico_City', '2026-07-27', '2026-07-27T06:00:00.000+0000'], // UTC-6, no DST
+		['Pacific/Kiritimati', '2026-08-09', '2026-08-08T10:00:00.000+0000'], // UTC+14
+		['UTC', '2026-08-09', '2026-08-09T00:00:00.000+0000'],
+	])('resolves midnight in task timeZone %s on %s to the correct UTC instant', (timeZone, date, expectedIsoDate) => {
+		const result = dateMan.parseDates(`Some task 📅 ${date}`, timeZone);
+
+		expect(result.dueDate).toMatchObject({ date, isoDate: expectedIsoDate });
+	});
+
+	it('is unaffected by host OS timezone -- only the passed timeZone parameter matters', () => {
+		const line = 'Some task 📅 2026-07-27';
+		const taskTimeZone = 'America/Mexico_City';
+
+		process.env.TZ = 'Pacific/Kiritimati'; // host far ahead of UTC
+		const eastHost = dateMan.parseDates(line, taskTimeZone);
+
+		process.env.TZ = 'Etc/GMT+12'; // host far behind UTC
+		const westHost = dateMan.parseDates(line, taskTimeZone);
+
+		expect(eastHost.dueDate?.isoDate).toBe('2026-07-27T06:00:00.000+0000');
+		expect(westHost.dueDate?.isoDate).toBe(eastHost.dueDate?.isoDate);
+	});
+
+	it('produces an identical isoDate on repeated parses of the same line', () => {
+		// isoDate (not date, which is just an echo of the regex match) is
+		// the field #366 actually affects. Guards against any per-call
+		// state drift in DateMan itself.
+		const line = 'Some task 📅 2026-08-09';
+
+		const isoDates = Array.from({ length: 5 }, () => dateMan.parseDates(line, 'Pacific/Kiritimati').dueDate?.isoDate);
+
+		expect(isoDates).toEqual(Array(5).fill('2026-08-08T10:00:00.000+0000'));
+	});
+});


### PR DESCRIPTION
Fix all-day task date drift bug (timezone parsing in extractDates)

Fixes #366.

## Bug

In `dateMan.ts` `extractDates()`, date-only (all-day) values were built into a bare local-midnight string with no timezone offset (`${dateData[2]}T00:00:00.000`) and handed to `new Date(...)`, which parses as host-OS-local midnight rather than UTC or the task's own timeZone. Repeated round-trips shifted the effective UTC instant and could land on a different calendar day once re-displayed/re-parsed (observed: an all-day dueDate decrementing by ~1 day per sync round-trip).

## Fix

Construct the all-day date string with explicit UTC (`T00:00:00.000Z`) instead of relying on implicit host-local parsing, so the value round-trips as the same calendar day regardless of host timezone.

Audited the other `new Date(...)` call sites in dateMan.ts (lines 85, 102, 320, 325, 361, 390): all of them operate on either genuine wall-clock times (user-entered hours:minutes) or full ISO strings already carrying an explicit offset from the TickTick API, so none had the same bare date-only/no-offset pattern and none needed changes.

## Testing

Added `src/test/dateMan_timezone_drift.test.ts`: parses the same all-day date under two host timezones on opposite sides of UTC and asserts the exact `isoDate`, plus a second test asserting `isoDate` stays identical across repeated parses of the same line (guards against any per-call state drift in `DateMan` itself).

`npm test` — 234 passed (19 test files).