### PR TITLE
fix: create the project-to-file mapping on first sync

### DIFF
--- a/src/services/ProjectSyncService.ts
+++ b/src/services/ProjectSyncService.ts
@@ -65,10 +65,14 @@ export class ProjectSyncService {
 		const fileMetadatas = await this.plugin.fileMetadataService.getAllFileMetadata();
 		if (!fileMetadatas) return;
 		const projects = await getAllProjects();
-		if (!projects || Object.keys(projects).length == 0) return;
 
 		const project = projects.find(p => p.id === ttProjectId);
-		if (!project) {
+		// A project needs a file mapping whether it is brand new to us or was
+		// cached before we ever managed to map it to a file (first run: the
+		// projects cache is populated in the same pass, so nothing ever looks
+		// "new" again and the mapping would never be created).
+		const mappedPath = await this.plugin.fileMetadataService.getFilepathForProjectId(ttProjectId);
+		if (!mappedPath) {
 			let newFilePath: string;
 			const folder = getDefaultFolder();
 			const sanitize = (name: string): string =>
@@ -89,11 +93,11 @@ export class ProjectSyncService {
 				newFilePath = (folder ? folder + "/" : "") + safeProjectName + '.md';
 			}
 
-			log.debug(`New project detected: ${ttProjectName} (${ttProjectId}). Creating file entry: ${newFilePath}`);
+			log.debug(`Unmapped project: ${ttProjectName} (${ttProjectId}). Creating file entry: ${newFilePath}`);
 			await upsertFile(newFilePath, ttProjectId);
 			return;
 		}
-		if (project?.name !== ttProjectName) {
+		if (project && project.name !== ttProjectName) {
 			log.debug(`Project Name Changed from ${project?.name} to ${ttProjectName}`)
 
 			const files = await getAllFiles();

--- a/src/test/services/ProjectSyncService.test.ts
+++ b/src/test/services/ProjectSyncService.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IProject } from '@/api/types/Project';
+
+vi.mock('obsidian', () => ({
+	App: vi.fn(),
+	AbstractInputSuggest: class {},
+	Modal: vi.fn(),
+	Notice: vi.fn(),
+	Plugin: vi.fn(),
+	PluginSettingTab: vi.fn(),
+	TFile: vi.fn(),
+	TFolder: vi.fn(),
+	MarkdownView: vi.fn(),
+}));
+
+vi.mock('@/utils/logger', () => ({
+	default: { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+const projectsTable = new Map<string, { id: string; project: IProject }>();
+const filesTable = new Map<string, { path: string; defaultProjectId?: string }>();
+
+vi.mock('@/db/dexie', () => ({
+	db: {
+		projects: {
+			get: vi.fn(async (id: string) => projectsTable.get(id)),
+			bulkPut: vi.fn(async (rows: Array<{ id: string; project: IProject }>) => {
+				rows.forEach(r => projectsTable.set(r.id, r));
+			}),
+			toArray: vi.fn(async () => [...projectsTable.values()]),
+		},
+		projectGroups: { get: vi.fn(async () => undefined) },
+	},
+}));
+
+vi.mock('@/db/projects', () => ({
+	getAllProjects: vi.fn(async () => [...projectsTable.values()].map(r => r.project)),
+	getProjectById: vi.fn(async (id: string) => projectsTable.get(id)?.project),
+}));
+
+const upsertFile = vi.fn(async (path: string, defaultProjectId?: string) => {
+	filesTable.set(path, { path, defaultProjectId });
+});
+
+vi.mock('@/db/files', () => ({
+	upsertFile: (path: string, id?: string) => upsertFile(path, id),
+	getAllFiles: vi.fn(async () => [...filesTable.values()]),
+	getFile: vi.fn(async (p: string) => filesTable.get(p)),
+	deleteFile: vi.fn(),
+}));
+
+vi.mock('@/settings', () => ({
+	getSettings: vi.fn(() => ({
+		inboxID: 'inbox-1',
+		inboxName: 'Inbox',
+		keepProjectFolders: false,
+	})),
+	getDefaultFolder: vi.fn(() => ''),
+	updateSettings: vi.fn(),
+}));
+
+vi.mock('@/modals/FoundDuplicateListsModal', () => ({
+	FoundDuplicateListsModal: vi.fn(function () {
+		return { showModal: vi.fn().mockResolvedValue(true) };
+	}),
+}));
+
+import { ProjectSyncService } from '@/services/ProjectSyncService';
+
+const remoteProjects = (): IProject[] => ([
+	{ id: 'proj-a', name: 'Work' } as IProject,
+	{ id: 'proj-b', name: 'Home' } as IProject,
+]);
+
+function makePlugin() {
+	const updateFilePath = vi.fn(async () => {});
+	return {
+		plugin: {
+			fileMetadataService: {
+				getAllFileMetadata: vi.fn(async () => ({})),
+				getFilepathForProjectId: vi.fn(async (id: string) => {
+					for (const f of filesTable.values()) {
+						if (f.defaultProjectId === id) return f.path;
+					}
+					return undefined;
+				}),
+				updateFilePath,
+			},
+		},
+		updateFilePath,
+	};
+}
+
+describe('ProjectSyncService.saveProjectsToCache', () => {
+	beforeEach(() => {
+		projectsTable.clear();
+		filesTable.clear();
+		upsertFile.mockClear();
+	});
+
+	it('maps every project to a file on the very first sync', async () => {
+		const { plugin } = makePlugin();
+		const svc = new ProjectSyncService({} as never, plugin as never);
+
+		// A fresh install starts with an empty projects cache.
+		expect(projectsTable.size).toBe(0);
+
+		await svc.saveProjectsToCache(remoteProjects());
+
+		const mapped = upsertFile.mock.calls.map(c => c[0]);
+		expect(mapped).toContain('Work.md');
+		expect(mapped).toContain('Home.md');
+		expect(mapped).toContain('Inbox.md');
+	});
+
+	it('does not re-create mappings on subsequent syncs', async () => {
+		const { plugin } = makePlugin();
+		const svc = new ProjectSyncService({} as never, plugin as never);
+
+		await svc.saveProjectsToCache(remoteProjects());
+		upsertFile.mockClear();
+
+		await svc.saveProjectsToCache(remoteProjects());
+		await svc.saveProjectsToCache(remoteProjects());
+
+		expect(upsertFile).not.toHaveBeenCalled();
+	});
+
+	it('leaves every project resolvable to a file path', async () => {
+		const { plugin } = makePlugin();
+		const svc = new ProjectSyncService({} as never, plugin as never);
+
+		await svc.saveProjectsToCache(remoteProjects());
+
+		const resolve = plugin.fileMetadataService.getFilepathForProjectId;
+		expect(await resolve('proj-a')).toBe('Work.md');
+		expect(await resolve('proj-b')).toBe('Home.md');
+		expect(await resolve('inbox-1')).toBe('Inbox.md');
+	});
+
+	it('still relocates the file when a project is renamed in TickTick', async () => {
+		const { plugin, updateFilePath } = makePlugin();
+		const svc = new ProjectSyncService(
+			{ vault: { getAbstractFileByPath: () => null } } as never,
+			plugin as never
+		);
+
+		// Project is already cached under its old name and already mapped to a file.
+		projectsTable.set('proj-a', { id: 'proj-a', project: { id: 'proj-a', name: 'Work' } as IProject });
+		filesTable.set('Work.md', { path: 'Work.md', defaultProjectId: 'proj-a' });
+
+		await svc.checkProjectRename('proj-a', 'Work Stuff');
+
+		expect(updateFilePath).toHaveBeenCalledWith('Work.md', 'Work Stuff.md');
+	});
+});


### PR DESCRIPTION
## Problem

On a fresh install, nothing is ever written to the vault. Login works, the pull works (the task count and the orphan list in **Maintenance → Check Database** both show the tasks correctly), but no file is created and no task line appears. **Check Database → "Add to file & db"** reports `Added N orphaned task(s) to vault and database.` and does nothing. Manual sync behaves the same way, with no error in the console.

## Cause

`ProjectSyncService.checkProjectRename()` contains the only code that maps a TickTick project to a vault file, and its bootstrap branch can never run:

```ts
const projects = await getAllProjects();
if (!projects || Object.keys(projects).length == 0) return;   // ← line 68

const project = projects.find(p => p.id === ttProjectId);
if (!project) {
    ...
    await upsertFile(newFilePath, ttProjectId);                // ← the only bootstrap
```

* **First sync:** `db.projects` is empty, so the line 68 guard returns early for every project. `saveProjectsToCache()` then does `db.projects.bulkPut(...)` and caches them all.
* **Every later sync:** the projects are in the cache, so `projects.find(...)` always matches, `if (!project)` is false, and the branch is skipped. Names match, so the rename path does nothing either.

So no `db.files` record ever receives a `defaultProjectId`. `getFilepathForProjectId()` returns `undefined` for every project, `VaultSyncCoordinator.determineTargetFile()` returns `undefined`, and every pulled task is dropped silently:

```ts
if (!targetFile) continue;   // VaultSyncCoordinator.ts:70
```

`pullFromTickTick()` stores each task with `file: ""`, which is why the plugin clearly has the data while producing no files.

The orphan modal fails through the same `undefined` (`services/index.ts:630`):

```ts
const targetFilepath = t.filepath || (await getFilepathForProjectId(t.projectId)) || '';
await this.plugin.taskRepository.upsertTask(t.task, targetFilepath, Date.now());
if (!t.inFile && targetFilepath) {          // '' → falsy → the file write never happens
```

It updates the database, skips the write, then shows the success notice.

**Vaults upgraded from 1.x are unaffected**, because `initDB()` migrates the old `fileMetadata` into `db.files` with the project ids already attached. That is why this only reproduces on a clean install.

## Reproduction

1. New vault, install 2.0.1, log in.
2. Manual sync, or **Maintenance → Check Database**.
3. The orphan list shows the tasks grouped by project name (the group falls back to `projectName` precisely because `filepath` is empty). Choose **Add to file & db**.
4. Success notice, no file created, no task written. Repeats on every subsequent sync.

Verified against the plugin's own IndexedDB after several syncs: `db.projects` correctly held both projects, `db.tasks` held every pulled task, and all seven `db.files` records had `defaultProjectId: undefined`.

## Fix

Key the bootstrap off whether the project already has a file mapping rather than whether it is new to the projects cache. This is idempotent, and it also repairs existing installs whose mapping is missing.

The rename branch is now guarded with `project &&` so that a project which is new to the cache but already mapped cannot fall into it with `project === undefined`.

## Tests

`src/test/services/ProjectSyncService.test.ts` (new, 4 cases):

* every project is mapped to a file on the first sync — **fails without the fix** (`expected [] to include 'Work.md'`)
* every project resolves to a file path afterwards — **fails without the fix** (`expected undefined to be 'Work.md'`)
* repeated syncs create no further mappings (idempotency)
* a project renamed in TickTick still relocates its file (guards the branch this PR touches)

`235/235` tests pass across all 19 files, and `npm run check` is clean. `npm run lint` could not be run: the repo has no `eslint.config.*` and the installed ESLint is v10, which no longer reads `.eslintrc.*` — unrelated to this change, so I left it alone.

## Not addressed here

Two adjacent issues I ran into while tracking this down, both out of scope for this PR — happy to open separate issues or PRs if useful:

1. **`persistToFile()` is asymmetric.** The add path falls back to an update when the task is already in the file, but the update path has no fallback when the task is *absent*: `NewFileMap.updateTask()` logs `task ... not found in ...` and returns, then `persistToFile()` still calls `upsertTask(task, file.path, Date.now())`, recording a vault sync that never happened. `findMissingTaskIds()` subsequently reads those tasks as user-deleted and offers to delete them from TickTick. This is reachable on 1.x-migrated vaults, where the migration sets `file` but not `lastVaultSync`, so `determineActionNeeded()` classifies every task as `'update'`.
2. **`TaskDeletionHandler.checkFileForDeletedTasks()`** logs `"File content not readable ... assuming all tasks deleted"` and then continues rather than returning, so an unreadable or empty managed file can propagate deletions to TickTick.
