### PR TITLE
fix: write tasks the update path finds missing, and never infer deletions from an unreadable file

### DIFF
--- a/src/fileOperation.ts
+++ b/src/fileOperation.ts
@@ -508,6 +508,9 @@ export class FileOperation {
 
 			let lineText = '';
 			let filePath = fileMap.getFilePath();
+			//Did this task's line actually make it into the file? Only then may we
+			//record a vault sync for it.
+			let bLinePersisted = true;
 
 			lineText = await this.plugin.taskParser?.convertTaskToLine(task, numParentTabs);
 			//Tired of seeing duplicates because of Sync conflicts.
@@ -521,6 +524,12 @@ export class FileOperation {
 				} else {
 					fileMap.addTask(task, lineText);
 				}
+			} else if (fileMap.getTaskIndex(task.id) == -1) {
+				//it's in the cache, but not in the file. Just add it.
+				//Mirrors the add branch above: without this the update is a silent
+				//no-op, and the task is then read back as deleted from the vault.
+				log.warn('A Task was being updated but was not in file: ', task.id, task.title);
+				fileMap.addTask(task, lineText);
 			} else {
 				//For updates doing the dateHolder mambo here because we need to make sure we get old dates....
 				const oldTask = await this.plugin.taskRepository.loadTaskById(task.id);
@@ -545,7 +554,7 @@ export class FileOperation {
 						}
 					} else {
 						const bParentUpdate = this.plugin.taskParser?.isParentIdChanged(vaultTask, task);
-						fileMap.updateTask(task, lineText, bParentUpdate);
+						bLinePersisted = fileMap.updateTask(task, lineText, bParentUpdate);
 					}
 				} else {
 					//how would that happen????
@@ -587,7 +596,15 @@ export class FileOperation {
 			} else {
 				if (!bTaskMove) {
 					task.lineHash = lineHash;
-					await this.plugin.taskRepository.upsertTask(task, file.path, Date.now());
+					if (bLinePersisted) {
+						await this.plugin.taskRepository.upsertTask(task, file.path, Date.now());
+					} else {
+						//The line was never written, so don't claim a vault sync for it.
+						//Doing so makes the task look deleted-from-the-vault on the next
+						//scan, and offers it up for deletion in TickTick.
+						log.warn(`Not recording a vault sync for ${task.id}: its line was not written to ${file.path}`);
+						await this.plugin.taskRepository.upsertTask(task);
+					}
 				} else {
 					task.lineHash = lineHash;
 					let addedTask = (await this.plugin.tickTickRestAPI?.updateTask(task))!;

--- a/src/services/NewFileMap.ts
+++ b/src/services/NewFileMap.ts
@@ -103,12 +103,13 @@ export class NewFileMap {
 		return insertLine;
 	}
 
-	updateTask(task: ITask, taskLine: string, bParentUpdate = false) {
+	/** @returns true if the task's line was rewritten, false if the task was not in the file. */
+	updateTask(task: ITask, taskLine: string, bParentUpdate = false): boolean {
 		this.rebuildEntries();
 		const entry = this.entries.find(e => e.id === task.id);
 		if (!entry) {
 			log.warn(`updateTask: task ${task.id} not found in ${this.file.path}`);
-			return;
+			return false;
 		}
 
 		const oldLineIdx = entry.lineIdx;
@@ -159,6 +160,7 @@ export class NewFileMap {
 			}
 		}
 		this.rebuildEntries();
+		return true;
 	}
 
 	deleteTask(id: string, bKillTheChildren: boolean = false): number {

--- a/src/services/TaskDeletionHandler.ts
+++ b/src/services/TaskDeletionHandler.ts
@@ -66,7 +66,12 @@ export class TaskDeletionHandler {
 		}
 
 		if (!currentFileValue) {
-			log.warn('File content not readable:', filepath, "assuming all tasks deleted.");
+			//Never infer deletions from a file we could not read: every task the DB
+			//places in it would be treated as deleted and removed from TickTick.
+			const message = `TickTickSync: could not read ${filepath}. Skipping the deleted-task check for it, so no tasks will be removed from TickTick.`;
+			log.error(message);
+			new Notice(message, 5000);
+			return;
 		}
 
 		// Remove frontmatter from content

--- a/src/test/services/updatePathWritesMissingTasks.test.ts
+++ b/src/test/services/updatePathWritesMissingTasks.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Regression tests for #369.
+ *
+ * A task the database places in a file, but which is not actually in that file,
+ * used to be skipped silently by the update path and then recorded as synced.
+ * The next scan read it back as deleted-from-the-vault and offered to delete it
+ * from TickTick.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ITask } from '@/api/types/Task';
+import type { LocalTask } from '@/db/schema';
+
+const notices: string[] = [];
+
+vi.mock('obsidian', () => ({
+	App: vi.fn(),
+	AbstractInputSuggest: class {},
+	Modal: vi.fn(),
+	Notice: vi.fn(function (msg: string) { notices.push(msg); }),
+	Plugin: vi.fn(),
+	PluginSettingTab: vi.fn(),
+	TFile: vi.fn(),
+	TFolder: vi.fn(),
+	MarkdownView: vi.fn(),
+}));
+
+vi.mock('@/utils/logger', () => ({
+	default: { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn(), trace: vi.fn() },
+}));
+
+const tasksInFile: LocalTask[] = [];
+
+// fileOperation.ts imports TickTickSync from '@/main' as a value, which drags in
+// the whole plugin (and Svelte) — stub it out.
+vi.mock('@/main', () => ({ default: class {} }));
+
+vi.mock('@/db/dexie', () => ({
+	db: {
+		tasks: {
+			where: vi.fn(() => ({
+				equals: () => ({
+					toArray: async () => tasksInFile,
+					first: async () => tasksInFile[0],
+					count: async () => tasksInFile.length,
+				}),
+			})),
+			update: vi.fn(),
+			toArray: vi.fn(async () => tasksInFile),
+		},
+	},
+}));
+
+vi.mock('@/settings', () => ({
+	getSettings: vi.fn(() => ({ enableFullVaultSync: false })),
+	getDefaultFolder: vi.fn(() => ''),
+}));
+
+import { TFile } from 'obsidian';
+import { NewFileMap } from '@/services/NewFileMap';
+import { TaskDeletionHandler } from '@/services/TaskDeletionHandler';
+
+const STUB = '== Added by TickTickSync -- 2.0.1 == ';
+const TASK_LINE = '- [ ] a task #ticktick %%[ticktick_id:: task-1]%%';
+
+const taskParser = {
+	isMarkdownTask: (line: string) => /^\s*[-*+] \[[x ]\]/i.test(line),
+	getTickTickId: (line: string) => line.match(/%%\[ticktick_id::\s*(\S+?)\]%%/)?.[1] ?? null,
+	getNumTabs: () => 0,
+	getTabs: (line: string) => (line.match(/^\s*/)?.[0] ?? ''),
+};
+
+function makeFileMap(content: string) {
+	return new NewFileMap(
+		{ metadataCache: { getFileCache: () => ({ listItems: [] }) } } as never,
+		{ taskParser } as never,
+		Object.assign(Object.create(TFile.prototype), { path: 'TODO/Work.md' }) as never
+	);
+}
+
+const aTask = { id: 'task-1', projectId: 'proj-a', title: 'a task' } as ITask;
+
+describe('NewFileMap.updateTask', () => {
+	it('reports failure and writes nothing when the task is not in the file', async () => {
+		const fileMap = makeFileMap(STUB);
+		await fileMap.init(STUB);
+
+		const before = fileMap.getFileLines();
+		const written = fileMap.updateTask(aTask, TASK_LINE);
+
+		expect(written).toBe(false);
+		expect(fileMap.getFileLines()).toBe(before);
+	});
+
+	it('reports success and rewrites the line when the task is in the file', async () => {
+		const fileMap = makeFileMap(`${STUB}\n${TASK_LINE}`);
+		await fileMap.init(`${STUB}\n${TASK_LINE}`);
+
+		const written = fileMap.updateTask(aTask, '- [x] a task #ticktick %%[ticktick_id:: task-1]%%');
+
+		expect(written).toBe(true);
+		expect(fileMap.getFileLines()).toContain('- [x] a task');
+	});
+});
+
+describe('persistToFile: a task marked for update but missing from the file', () => {
+	it('is added to the file instead of being silently skipped', async () => {
+		const { FileOperation } = await import('@/fileOperation');
+
+		let written = '';
+		const file = Object.assign(Object.create(TFile.prototype), { path: 'TODO/Work.md' });
+
+		const app = {
+			workspace: { getActiveFile: () => null, activeEditor: null },
+			vault: {
+				getAbstractFileByPath: () => file,
+				read: async () => STUB,
+				cachedRead: async () => STUB,
+				process: async (_f: unknown, cb: (d: string) => string) => { written = cb(STUB); },
+			},
+			metadataCache: { getFileCache: () => ({ listItems: [] }) },
+		};
+
+		const upsertTask = vi.fn(async (..._args: unknown[]) => {});
+		const plugin = {
+			app,
+			taskParser: {
+				...taskParser,
+				convertTaskToLine: async () => TASK_LINE,
+				isProjectIdChanged: async () => false,
+				isParentIdChanged: () => false,
+				getNoteString: () => '',
+				getLineHash: async () => 'hash',
+				getLinkLocation: () => ({ taskURL: null, noteURL: null }),
+			},
+			dateMan: { addDateHolderToTask: () => {} },
+			taskRepository: { loadTaskById: async () => aTask, upsertTask },
+			fileTaskQueries: {
+				getDefaultProjectIdForFilepath: async () => 'proj-a',
+				filepathHasDefaultProjectID: async () => true,
+			},
+			tickTickRestAPI: { updateTask: async (t: ITask) => t },
+			lastLines: new Map<string, number>(),
+		};
+
+		const fileOperation = new FileOperation(app as never, plugin as never);
+		(plugin as unknown as { fileOperation: unknown }).fileOperation = fileOperation;
+
+		await fileOperation.synchronizeToVault('TODO/Work.md', [aTask], true);
+
+		// the line was actually written to the file...
+		expect(written).toContain('ticktick_id:: task-1');
+
+		// ...so recording a vault sync for it is now truthful
+		expect(upsertTask).toHaveBeenCalledTimes(1);
+		const [taskArg, pathArg, timestampArg] = upsertTask.mock.calls[0];
+		expect((taskArg as ITask).id).toBe('task-1');
+		expect(pathArg).toBe('TODO/Work.md');
+		expect(typeof timestampArg).toBe('number');
+	});
+});
+
+describe('TaskDeletionHandler on an unreadable file', () => {
+	beforeEach(() => {
+		notices.length = 0;
+		tasksInFile.length = 0;
+		tasksInFile.push({
+			localId: 'tt:task-1', taskId: 'task-1', task: aTask,
+			updatedAt: 1, file: 'TODO/Work.md', source: 'ticktick',
+		});
+	});
+
+	it('does not treat empty content as "every task deleted", and tells the user', async () => {
+		const file = Object.assign(Object.create(TFile.prototype), { path: 'TODO/Work.md' });
+		const deleteTasksByIds = vi.fn(async () => []);
+
+		const handler = new TaskDeletionHandler(
+			{ vault: { getAbstractFileByPath: () => file, getMarkdownFiles: () => [] } } as never,
+			{ fileOperation: { readFileContent: async () => '' } } as never
+		);
+		(handler as unknown as { deleteTasksByIds: unknown }).deleteTasksByIds = deleteTasksByIds;
+
+		await handler.checkFileForDeletedTasks('TODO/Work.md');
+
+		expect(deleteTasksByIds).not.toHaveBeenCalled();
+		expect(notices.some(n => n.includes('could not read'))).toBe(true);
+	});
+
+	it('still detects a genuine deletion when the file is readable', async () => {
+		const file = Object.assign(Object.create(TFile.prototype), { path: 'TODO/Work.md' });
+		const deleteTasksByIds = vi.fn(async () => []);
+
+		const handler = new TaskDeletionHandler(
+			{ vault: { getAbstractFileByPath: () => file, getMarkdownFiles: () => [] } } as never,
+			{ fileOperation: { readFileContent: async () => '- [ ] some other task\n' } } as never
+		);
+		(handler as unknown as { deleteTasksByIds: unknown }).deleteTasksByIds = deleteTasksByIds;
+
+		await handler.checkFileForDeletedTasks('TODO/Work.md');
+
+		expect(deleteTasksByIds).toHaveBeenCalledWith(['task-1']);
+	});
+});


### PR DESCRIPTION
Fixes #369. Thanks for the quick look at that one — this implements all three, including the `Notice` you asked for on the read failure.

## 1. `persistToFile()` was asymmetric

The add path already falls back to an update when the task turns out to be in the file:

```ts
if (!bUpdating) {
    if (fileMap.getTaskIndex(task.id) != -1) {
        log.warn('A Task was being added but was already in file: ', task.id, task.title);
        fileMap.updateTask(task, lineText);   // falls back
```

The update path had no fallback for the inverse. `NewFileMap.updateTask()` logged and returned:

```ts
const entry = this.entries.find(e => e.id === task.id);
if (!entry) {
    log.warn(`updateTask: task ${task.id} not found in ${this.file.path}`);
    return;                       // nothing written
}
```

…and `persistToFile()` then recorded the sync anyway:

```ts
task.lineHash = lineHash;
await this.plugin.taskRepository.upsertTask(task, file.path, Date.now());
```

So the database claimed the task lived in the file and had just been vault-synced, while the file did not contain it. On the next scan `findMissingTaskIds()` read it as user-deleted and `deleteTasksByIds()` offered to delete it from TickTick.

Now the update branch adds the task instead, mirroring the add branch.

## 2. A vault sync is only recorded when a line was written

`updateTask()` returns whether it rewrote the line, and `persistToFile()` gates the stamp on it. A task whose line was not written is still upserted, just without the `file`/`lastVaultSync` stamp, so it can never be mistaken for one the user deleted. Defence in depth — with change 1 the no-op path should no longer be reachable, but `getTaskIndex()` (scans `fileLines`) and `updateTask()` (uses `entries` from `rebuildEntries()`) determine presence by different means and could in principle disagree.

## 3. Unreadable files no longer imply deletion

```ts
if (!currentFileValue) {
    log.warn('File content not readable:', filepath, "assuming all tasks deleted.");
}
// execution continued
```

Now returns, and raises a `Notice` as you suggested, so the user learns the check was skipped rather than silently wondering why nothing syncs.

## Why this is reachable

Vaults migrated from 1.x. Both `migrateFromDataJson()` (`migrations.ts:31-39`) and the inline fallback in `initDB()` build `LocalTask` records that set `file` from the old `fileMetadata` but never set `lastVaultSync`. `determineActionNeeded()` therefore classifies every migrated task as `'update'` forever:

```ts
const isNew = !lt.file;                                     // false
const hasChanged = lt.updatedAt > (lt.lastVaultSync || 0);   // true
```

Combined with 1, the managed files stay at the creation stub and every task in them looks user-deleted. That's the reported symptom.

## Tests

`src/test/services/updatePathWritesMissingTasks.test.ts` — 5 cases, **4 of which fail without this change**:

| test | without the fix |
|---|---|
| `updateTask()` reports failure and writes nothing when the task is absent | `expected undefined to be false` |
| `updateTask()` reports success and rewrites the line when present | `expected undefined to be true` |
| a task marked for update but missing from the file is added | `expected '' to contain 'ticktick_id:: task-1'` |
| an unreadable file does not trigger deletions, and notifies | `expected vi.fn() to not be called at all, but actually been called 1 times` |
| a genuine deletion is still detected when the file is readable | passes both ways — guards against over-correcting |

`245/245` tests pass across all 21 files, `npm run check` is clean, and `npm run build` succeeds.

As on #368, I couldn't run `npm run lint`: there's no `eslint.config.*` in the repo and the installed ESLint is v10, which no longer reads `.eslintrc.*`. Left alone as unrelated — happy to send a separate PR migrating the config if you'd like.
