### PR TITLE
Fix Android reminders by generating reminder IDs

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -502,11 +502,11 @@ export class Tick {
 				// date to "now" (issue #209).
 				completedTime: task.completedTime ?? null,
 				// POST /task uses the legacy web API's native {id, trigger}
-				// reminder shape (same as batch/check). Empty string id tells
-				// TickTick to generate one. The singular `reminder` field must
-				// carry the first (or only) trigger.
+				// reminder shape (same as batch/check). Generate reminder ids
+				// client-side, matching the TickTick/Dida web client. The singular
+				// `reminder` field must carry the first (or only) trigger.
 				reminder: triggers[0] || task.reminder || null,
-				reminders: triggers.map(t => ({ id: '', trigger: t })),
+				reminders: triggers.map(t => ({ id: ObjectID().toHexString(), trigger: t })),
 				repeatFlag: task.repeatFlag ? task.repeatFlag : null as unknown as string,
 				priority: task.priority ? task.priority : 0,
 				status: task.status ? task.status : 0,
@@ -576,10 +576,11 @@ export class Tick {
 				// silently drops all reminders on update.
 				reminder: jsonOptions.reminders?.[0] ? normalizeTrigger(jsonOptions.reminders[0].trigger) : (jsonOptions.reminder || null),
 				// batch/task uses the {id, trigger} object form returned by the web sync API.
-				// Existing reminders keep their TickTick id; new ones get an empty string.
+				// Existing reminders keep their TickTick id; new ones get a client-generated
+				// ObjectId, matching reminders created by the TickTick/Dida web client.
 				// Triggers are normalized to the positive canonical form TickTick accepts.
 				reminders: (jsonOptions.reminders || []).map(r => ({
-					id: r.id || '',
+					id: r.id || ObjectID().toHexString(),
 					trigger: r.id ? r.trigger : normalizeTrigger(r.trigger),
 				})),
 				repeatFlag: jsonOptions.repeatFlag ? jsonOptions.repeatFlag : null as unknown as string,

--- a/src/test/api/reminderPayload.test.ts
+++ b/src/test/api/reminderPayload.test.ts
@@ -40,17 +40,23 @@ function makeTask(overrides: Partial<ITask> = {}): ITask {
 }
 
 describe('addTask payload reminders', () => {
-	it('sends reminders as {id, trigger} objects with empty id on create', async () => {
+	it('sends reminders with client-generated ObjectIds on create', async () => {
 		const { tick, mock } = makeApi();
 		const task = makeTask({ reminders: [{ trigger: 'TRIGGER:PT30M' }, { trigger: 'TRIGGER:P1D' }] });
 
 		await tick.addTask(task);
 
 		const body = mock.mock.calls[0][3];
-		expect(body.reminders).toEqual([
-			{ id: '', trigger: 'TRIGGER:PT30M' },
-			{ id: '', trigger: 'TRIGGER:P1D' },
-		]);
+		expect(body.reminders).toHaveLength(2);
+		expect(body.reminders[0]).toEqual({
+			id: expect.stringMatching(/^[a-f0-9]{24}$/),
+			trigger: 'TRIGGER:PT30M',
+		});
+		expect(body.reminders[1]).toEqual({
+			id: expect.stringMatching(/^[a-f0-9]{24}$/),
+			trigger: 'TRIGGER:P1D',
+		});
+		expect(body.reminders[0].id).not.toBe(body.reminders[1].id);
 	});
 
 	it('sets the singular reminder field to the first trigger on create', async () => {
@@ -72,14 +78,18 @@ describe('addTask payload reminders', () => {
 		expect(body.reminders).toEqual([]);
 	});
 
-	it('always uses empty id for reminders on create (no task exists yet)', async () => {
+	it('replaces local reminder ids on create because no remote reminder exists yet', async () => {
 		const { tick, mock } = makeApi();
 		const task = makeTask({ reminders: [{ id: 'r1', trigger: 'TRIGGER:PT30M' }] });
 
 		await tick.addTask(task);
 
 		const body = mock.mock.calls[0][3];
-		expect(body.reminders).toEqual([{ id: '', trigger: 'TRIGGER:PT30M' }]);
+		expect(body.reminders).toEqual([{
+			id: expect.stringMatching(/^[a-f0-9]{24}$/),
+			trigger: 'TRIGGER:PT30M',
+		}]);
+		expect(body.reminders[0].id).not.toBe('r1');
 	});
 
 	it('returns the created task directly', async () => {
@@ -105,7 +115,7 @@ describe('addTask payload reminders', () => {
 });
 
 describe('updateTask payload reminders', () => {
-	it('sends reminders as {id, trigger} objects on update, empty id for new ones', async () => {
+	it('preserves existing reminder ids and generates ObjectIds for new reminders on update', async () => {
 		const { tick, mock } = makeApi();
 		const task = makeTask({
 			reminders: [{ id: 'r1', trigger: 'TRIGGER:-PT35M' }, { trigger: 'TRIGGER:PT30M' }],
@@ -116,7 +126,7 @@ describe('updateTask payload reminders', () => {
 		const payload = mock.mock.calls[0][3];
 		expect(payload.update[0].reminders).toEqual([
 			{ id: 'r1', trigger: 'TRIGGER:-PT35M' },
-			{ id: '', trigger: 'TRIGGER:PT30M' },
+			{ id: expect.stringMatching(/^[a-f0-9]{24}$/), trigger: 'TRIGGER:PT30M' },
 		]);
 	});
 


### PR DESCRIPTION
## Background

Thank you for fixing #384 and adding reminder support.

After testing the fix, I found that reminders created or updated from Obsidian were successfully synchronized to the Dida365 web app:

https://dida365.com/webapp/

However, those reminders did not appear in the Dida365 Android app and did not trigger Android notifications.

By comparison, when I created a task with a reminder directly in the Dida365 web app, the reminder synchronized to Android correctly and the notification fired as expected.

## Investigation

I compared the payload generated by TickTickSync with a task created by the Dida365 web app.

TickTickSync previously sent a newly added reminder with an empty ID:

```json
{
  "reminders": [
    {
      "id": "",
      "trigger": "TRIGGER:PT0S"
    }
  ]
}
```

The Dida365 web app generates a separate 24-character ObjectId for every new reminder:

```json
{
  "reminders": [
    {
      "id": "0123456789abcdef01234567",
      "trigger": "TRIGGER:PT0S"
    }
  ]
}
```

The web app appears to tolerate reminders with an empty ID, which is why the reminder was visible and functional there. However, the Android app did not synchronize or schedule reminders without an ID.

## Changes

This PR aligns newly created reminders with the payload produced by the Dida365 web app:
- Generate a client-side ObjectId for each reminder when creating a task.
- Preserve existing reminder IDs when updating a task.
- Generate an ObjectId for newly added reminders during task updates.
- Update the reminder payload tests to cover generated and preserved IDs.

The project already uses bson-objectid to generate task IDs, so this change does not introduce a new dependency.

## Verification

Tested against dida365.com with the following cases:

### Create a task with a reminder

Created a new timed task in Obsidian using:

```markdown
- [ ] [22:10] Reminder test ⏰ 0m #ticktick 📅 2026-08-19
```

Result:
- Task synchronized to the Dida365 web app.
- Reminder appeared in the Dida365 web app.
- Reminder synchronized to the Android app.
- Android notification fired at the configured time.

### Add or update a reminder

Added or changed a reminder on an existing synchronized task.

Result:
- Existing reminder IDs were preserved.
- Newly added reminders received an ObjectId.
- Changes synchronized to both the web app and Android.
- Android notification fired correctly.

## Tests

```
Test Files  28 passed (28)
Tests  346 passed (346)
```

Tested with:
- TickTickSync: current master
- Obsidian: 1.13.7
- Desktop: macOS Tahoe 26.5.2
- Mobile: Xiaomi 14
- Mobile OS: Xiaomi HyperOS 3.0.303.0
- Service: Dida365